### PR TITLE
decorated with asyncio.coroutine

### DIFF
--- a/aiohttp_debugtoolbar/panels/performance.py
+++ b/aiohttp_debugtoolbar/panels/performance.py
@@ -50,6 +50,7 @@ class PerformanceDebugPanel(DebugPanel):
 
     def _wrap_timer_handler(self, handler):
         if self.has_resource:
+            @asyncio.coroutine
             def resource_timer_handler(request):
                 _start_time = time.time()
                 self._start_rusage = resource.getrusage(resource.RUSAGE_SELF)
@@ -65,6 +66,7 @@ class PerformanceDebugPanel(DebugPanel):
 
             return resource_timer_handler
 
+        @asyncio.coroutine
         def noresource_timer_handler(request):
             _start_time = time.time()
             try:


### PR DESCRIPTION
I had a problem while trying to run aiohttp project with python's 3.5 native coroutines
I got this:
```
Traceback (most recent call last):
  File ".env/lib/python3.5/site-packages/aiohttp_debugtoolbar/utils.py", line 168, in __call__
    _y = next(_i)
  File ".env/lib/python3.5/site-packages/aiohttp_debugtoolbar/panels/performance.py", line 57, in resource_timer_handler
    result = yield from handler(request)
TypeError: cannot 'yield from' a coroutine object in a non-coroutine generator
```

So, i guess `resource_timer_handler` and `noresource_timer_handler` should be a coroutines