### PR TITLE
Update utils.py

### DIFF
--- a/aiohttp_debugtoolbar/utils.py
+++ b/aiohttp_debugtoolbar/utils.py
@@ -6,15 +6,10 @@ import sys
 from collections import deque
 from itertools import islice
 
-from http.client import (
-    MOVED_PERMANENTLY,  # 301
-    FOUND,  # 302
-    SEE_OTHER)  # 303
-
 APP_KEY = 'aiohttp_debugtollbar'
 TEMPLATE_KEY = 'aiohttp_debugtollbar_jinja2'
 
-REDIRECT_CODES = (MOVED_PERMANENTLY, FOUND, SEE_OTHER)
+REDIRECT_CODES = (300, 301, 302, 303, 305, 307, 308)
 STATIC_PATH = 'static/'
 ROOT_ROUTE_NAME = 'debugtoolbar.main'
 STATIC_ROUTE_NAME = 'debugtoolbar.static'

--- a/aiohttp_debugtoolbar/utils.py
+++ b/aiohttp_debugtoolbar/utils.py
@@ -6,10 +6,15 @@ import sys
 from collections import deque
 from itertools import islice
 
+from http.client import (
+    MOVED_PERMANENTLY,  # 301
+    FOUND,  # 302
+    SEE_OTHER)  # 303
+
 APP_KEY = 'aiohttp_debugtollbar'
 TEMPLATE_KEY = 'aiohttp_debugtollbar_jinja2'
 
-REDIRECT_CODES = (301, 302, 303, 304)
+REDIRECT_CODES = (MOVED_PERMANENTLY, FOUND, SEE_OTHER)
 STATIC_PATH = 'static/'
 ROOT_ROUTE_NAME = 'debugtoolbar.main'
 STATIC_ROUTE_NAME = 'debugtoolbar.static'


### PR DESCRIPTION
The HTTPNotModified exception of aiohttp correctly [1] does not set the location attribute in the response.

This causes an AttributeError in aiohttp_debugtoolbar/middlewares.py, at line "if response.status in REDIRECT_CODES and response.location:".

The proposed solution is removing the 304 code from the following line in the utils.py file and using the HTTP codes constants [2], i.e. from: 

REDIRECT_CODES = (301, 302, 303, 304)

to:

from http.client import (
    MOVED_PERMANENTLY,  # 301
    FOUND,  # 302
    SEE_OTHER)  # 303
REDIRECT_CODES = (MOVED_PERMANENTLY, FOUND, SEE_OTHER)

I'm against a change like the following one in middlewares.py, from
"if response.status in REDIRECT_CODES and response.location:"
into
"if response.status in REDIRECT_CODES and getattr(response, 'location', None):"
because http.client.NOT_MODIFIED (304) responses do not make provision for a "Location" Response header.



[1] http://www.w3.org/Protocols/HTTP/HTRESP.html
[2] https://docs.python.org/3.5/library/http.html#http-status-codes